### PR TITLE
 add required rpms-signature-scan task

### DIFF
--- a/pipelines/multi-arch-build-pipeline.yaml
+++ b/pipelines/multi-arch-build-pipeline.yaml
@@ -336,6 +336,28 @@ spec:
         - name: kind
           value: task
         resolver: bundles
+    - name: rpms-signature-scan
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:7aa4d3c95e2b963e82fdda392f7cb3d61e3dab035416cf4a3a34e43cf3c9c9b8
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
     params:
     - description: Source Repository URL
       name: git-url


### PR DESCRIPTION
Enterprise checks are failing with

```
✕ [Violation] tasks.required_tasks_found
  ImageRef: quay.io/redhat-user-workloads/app-sre-tenant/shared-pipelines-main/shared-pipelines-main@sha256:1f1c81526ffed8d5057efb4720fb832813b0439f76f1c6f79d98becc0ea818ff
  Reason: Required task "rpms-signature-scan" is missing
  Title: All required tasks were included in the pipeline
  Description: Ensure that the set of required tasks are included in the PipelineRun attestation. To exclude this rule add
  "tasks.required_tasks_found:rpms-signature-scan" to the `exclude` section of the policy configuration.
  Solution: Make sure all required tasks are in the build pipeline. The required task list is contained as
  xref:ec-cli:ROOT:configuration.adoc#_data_sources[data] under the key 'required-tasks'.
```