### PR TITLE
Add task-rpms-signature-scan that is required by EC since Nov 01

### DIFF
--- a/pipelines/multi-arch-build-pipeline.yaml
+++ b/pipelines/multi-arch-build-pipeline.yaml
@@ -186,6 +186,28 @@ spec:
         operator: in
         values:
         - "true"
+    - name: rpms-signature-scan
+      params:
+      - name: IAMGE_URL
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:0c18e0e697f0050269d22cc491c38672d31c6985bd2494efd67a5ff7d909d013
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
     - name: deprecated-base-image-check
       params:
       - name: IMAGE_URL


### PR DESCRIPTION
PRs that use Enterprise Contract (EC) checks are failing because the task rpms-signature-scan is mandatory.

i.e:
https://github.com/app-sre/go-qontract-reconcile/pull/98

This adds the task to the default pipeline.