### PR TITLE
:sparkles: renovate: enable pep621 python manager

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -38,13 +38,18 @@
     "terragrunt-version",
     "tflint-plugin",
     "pip_requirements",
-    "pip_setup"
+    "pip_setup",
+    "pep621"
   ],
   "pip_requirements": {
     "additionalBranchPrefix": "{{baseBranch}}/",
     "branchPrefix": "konflux/mintmaker/"
   },
   "pip_setup": {
+    "additionalBranchPrefix": "{{baseBranch}}/",
+    "branchPrefix": "konflux/mintmaker/"
+  },
+  "pep621": {
     "additionalBranchPrefix": "{{baseBranch}}/",
     "branchPrefix": "konflux/mintmaker/"
   },


### PR DESCRIPTION
Enable [pep621](https://docs.renovatebot.com/modules/manager/pep621/) Python manager to keep track of dependencies managed via `pyproject.toml`.