### PR TITLE
:page_facing_up: add missing license file to final image

### DIFF
--- a/pipeline-tests/Dockerfile
+++ b/pipeline-tests/Dockerfile
@@ -1,2 +1,2 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4@sha256:c0e70387664f30cd9cf2795b547e4a9a51002c44a4a86aa9335ab030134bf392
-
+COPY LICENSE /licenses/LICENSE


### PR DESCRIPTION
The enterprise-contract enforces this file in our image.