### PR TITLE
:sparkles: enable automerge of uv updates

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -59,6 +59,13 @@
     {
       "matchPackageNames": ["pytest**"],
       "groupName": "pytest"
+    },
+    {
+      "description": "Automerge updates to uv",
+      "matchPackageNames": ["ghcr.io/astral-sh/uv"],
+      "datasources": ["docker"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
Allow automatic PR merge of `ghcr.io/astral-sh/uv` image updates.