### PR TITLE
Fix EC

### DIFF
--- a/pipeline-tests/Dockerfile
+++ b/pipeline-tests/Dockerfile
@@ -1,2 +1,3 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:d85040b6e3ed3628a89683f51a38c709185efc3fb552db2ad1b9180f2a6c38be
 COPY LICENSE /licenses/LICENSE
+USER 1001


### PR DESCRIPTION
Fix enterprise contract failure:

```
"failed": [
            {
                "name": "RunAsNonRoot",
                "elapsed_time": 0,
                "description": "Checking if container runs as the root user because a container that does not specify a non-root user will fail the automatic certification, and will be subject to a manual review before the container can be approved for publication",
                "help": "Check RunAsNonRoot encountered an error. Please review the preflight.log file for more information.",
                "suggestion": "Indicate a specific USER in the dockerfile or containerfile",
                "knowledgebase_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction",
                "check_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
            }
        ],
```