### PR TITLE
:zap: disable arm64 builds

### DIFF
--- a/pipelines/multi-arch-build-pipeline.yaml
+++ b/pipelines/multi-arch-build-pipeline.yaml
@@ -417,7 +417,8 @@ spec:
       type: string
     - default:
       - linux/x86_64
-      - linux/arm64
+      # Disable arm builds until they are in-cluster or much faster!
+      # - linux/arm64
       description: List of platforms to build the container images on. The available
         set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms


### PR DESCRIPTION
Builds on the arm64 architecture are very slow and add at least 10 minutes to every pipeline run. :( Konflux builds aren't reliable yet, and I don't want to spend this additional time.