### PR TITLE
disable multi-arch pipeline

### DIFF
--- a/.tekton/multi-arch-build-main-push-test.yaml
+++ b/.tekton/multi-arch-build-main-push-test.yaml
@@ -27,6 +27,8 @@ spec:
     value: pipeline-tests/Dockerfile
   - name: path-context
     value: .
+  - name: target-stage
+    value: prod
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/multi-arch-build-pull-request-test.yaml
+++ b/.tekton/multi-arch-build-pull-request-test.yaml
@@ -31,6 +31,8 @@ spec:
     value: pipeline-tests/Dockerfile
   - name: path-context
     value: .
+  - name: target-stage
+    value: test
   pipelineRef:
     resolver: git
     params:

--- a/pipeline-tests/Dockerfile
+++ b/pipeline-tests/Dockerfile
@@ -1,3 +1,7 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:d85040b6e3ed3628a89683f51a38c709185efc3fb552db2ad1b9180f2a6c38be
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:d85040b6e3ed3628a89683f51a38c709185efc3fb552db2ad1b9180f2a6c38be as prod
 COPY LICENSE /licenses/LICENSE
 USER 1001
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:d85040b6e3ed3628a89683f51a38c709185efc3fb552db2ad1b9180f2a6c38be as test
+
+COPY --from=prod /licenses/LICENSE /licenses/LICENSE

--- a/pipelines/multi-arch-build-pipeline.yaml
+++ b/pipelines/multi-arch-build-pipeline.yaml
@@ -1,461 +1,927 @@
 ---
-# https://github.com/konflux-ci/build-definitions
-# https://konflux.pages.redhat.com/docs/users/getting-started/multi-platform-builds.html
+# TODO: remove this once multi-arch builds are reliable
+# Single arch build (amd64)
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
   name: multi-arch-build-pipeline
 spec:
-    tasks:
-    - name: init
-      params:
-      - name: image-url
-        value: $(params.output-image)
-      - name: rebuild
-        value: $(params.rebuild)
-      - name: skip-checks
-        value: $(params.skip-checks)
-      taskRef:
-        params:
-        - name: name
-          value: init
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:0523b51c28375a3f222da91690e22eff11888ebc98a0c73c468af44762265c69
-        - name: kind
-          value: task
-        resolver: bundles
-    - name: clone-repository
-      params:
-      - name: url
-        value: $(params.git-url)
-      - name: revision
-        value: $(params.revision)
-      - name: ociStorage
-        value: $(params.output-image).git
-      - name: ociArtifactExpiresAfter
-        value: $(params.image-expires-after)
-      runAfter:
-      - init
-      taskRef:
-        params:
-        - name: name
-          value: git-clone-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:4bf48d038ff12d25bdeb5ab3e98dc2271818056f454c83d7393ebbd413028147
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(tasks.init.results.build)
-        operator: in
-        values:
-        - "true"
-      workspaces:
-      - name: basic-auth
-        workspace: git-auth
-    - name: prefetch-dependencies
-      params:
-      - name: input
-        value: $(params.prefetch-input)
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
-      - name: ociStorage
-        value: $(params.output-image).prefetch
-      - name: ociArtifactExpiresAfter
-        value: $(params.image-expires-after)
-      runAfter:
-      - clone-repository
-      taskRef:
-        params:
-        - name: name
-          value: prefetch-dependencies-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.1@sha256:30c903144e8c8d8c65fb6ec40dd3ff737091609f96fa9f326c047f71242dade4
-        - name: kind
-          value: task
-        resolver: bundles
-      workspaces:
-      - name: git-basic-auth
-        workspace: git-auth
-      - name: netrc
-        workspace: netrc
-    - matrix:
-        params:
-        - name: PLATFORM
-          value:
-          - $(params.build-platforms)
-      name: build-images
-      params:
-      - name: IMAGE
-        value: $(params.output-image)
-      - name: DOCKERFILE
-        value: $(params.dockerfile)
-      - name: CONTEXT
-        value: $(params.path-context)
-      - name: HERMETIC
-        value: $(params.hermetic)
-      - name: PREFETCH_INPUT
-        value: $(params.prefetch-input)
-      - name: IMAGE_EXPIRES_AFTER
-        value: $(params.image-expires-after)
-      - name: TARGET_STAGE
-        value: $(params.target-stage)
-      - name: COMMIT_SHA
-        value: $(tasks.clone-repository.results.commit)
-      - name: BUILD_ARGS
-        value:
-        - $(params.build-args[*])
-      - name: BUILD_ARGS_FILE
-        value: $(params.build-args-file)
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-      - name: CACHI2_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      - name: IMAGE_APPEND_PLATFORM
-        value: "true"
-      runAfter:
-      - prefetch-dependencies
-      taskRef:
-        params:
-        - name: name
-          value: buildah-remote-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:d582f95f21735f44947c62c2976972dc062cba20e6a3694990bafd5827665bb7
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(tasks.init.results.build)
-        operator: in
-        values:
-        - "true"
-    - name: build-image-index
-      params:
-      - name: IMAGE
-        value: $(params.output-image)
-      - name: COMMIT_SHA
-        value: $(tasks.clone-repository.results.commit)
-      - name: IMAGE_EXPIRES_AFTER
-        value: $(params.image-expires-after)
-      - name: ALWAYS_BUILD_INDEX
-        value: $(params.build-image-index)
-      - name: IMAGES
-        value:
-        - $(tasks.build-images.results.IMAGE_REF[*])
-      runAfter:
-      - build-images
-      taskRef:
-        params:
-        - name: name
-          value: build-image-index
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:ebc17bb22481160eec6eb7277df1e48b90f599bebe563cd4f046807f4e32ced3
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(tasks.init.results.build)
-        operator: in
-        values:
-        - "true"
-    - name: build-source-image
-      params:
-      - name: BINARY_IMAGE
-        value: $(params.output-image)
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-      - name: CACHI2_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: source-build-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.1@sha256:bd786bc1d33391bb169f98a1070d1a39e410b835f05fd0db0263754c65bd9bea
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(tasks.init.results.build)
-        operator: in
-        values:
-        - "true"
-      - input: $(params.build-source-image)
-        operator: in
-        values:
-        - "true"
-    - name: deprecated-base-image-check
-      params:
-      - name: IMAGE_URL
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: IMAGE_DIGEST
-        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: deprecated-image-check
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.4@sha256:5a1a165fa02270f0a947d8a2131ee9d8be0b8e9d34123828c2bef589e504ee84
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-    - name: clair-scan
-      params:
-      - name: image-digest
-        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: clair-scan
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:0a5421111e7092740398691d5bd7c125cc0896f29531d19414bb5724ae41692a
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-    - name: ecosystem-cert-preflight-checks
-      params:
-      - name: image-url
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: ecosystem-cert-preflight-checks
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:df8a25a3431a70544172ed4844f9d0c6229d39130633960729f825a031a7dea9
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-    - name: sast-snyk-check
-      params:
-      - name: image-digest
-        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-      - name: CACHI2_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: sast-snyk-check-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.3@sha256:65a213322ea7c64159e37071d369d74b6378b23403150e29537865cada90f022
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-    - name: clamav-scan
-      params:
-      - name: image-digest
-        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: clamav-scan
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.1@sha256:b4f450f1447b166da671f1d5819ab5a1485083e5c27ab91f7d8b7a2ff994c8c2
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
-    - name: apply-tags
-      params:
-      - name: IMAGE
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: apply-tags
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:87fd7fc0e937aad1a8db9b6e377d7e444f53394dafde512d68adbea6966a4702
-        - name: kind
-          value: task
-        resolver: bundles
-    - name: push-dockerfile
-      params:
-      - name: IMAGE
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: IMAGE_DIGEST
-        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-      - name: DOCKERFILE
-        value: $(params.dockerfile)
-      - name: CONTEXT
-        value: $(params.path-context)
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: push-dockerfile-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:80d48a1b9d2707490309941ec9f79338533938f959ca9a207b481b0e8a5e7a93
-        - name: kind
-          value: task
-        resolver: bundles
-    - name: rpms-signature-scan
-      params:
-      - name: image-url
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: image-digest
-        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: rpms-signature-scan
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:28aaf87d61078a0aeeeabcae455eda7d05c4f9b81d8995bdcf3dde95c1a7a77b
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
+  finally:
+  - name: show-sbom
     params:
-    - description: Source Repository URL
-      name: git-url
-      type: string
-    - default: ""
-      description: Revision of the Source Repository
-      name: revision
-      type: string
-    - description: Fully Qualified Output Image
-      name: output-image
-      type: string
-    - default: .
-      description: Path to the source code of an application's component from where
-        to build image.
-      name: path-context
-      type: string
-    - default: Dockerfile
-      description: Path to the Dockerfile inside the context specified by parameter
-        path-context
-      name: dockerfile
-      type: string
-    - default: "false"
-      description: Force rebuild image
-      name: rebuild
-      type: string
-    - default: "false"
-      description: Skip checks against built image
-      name: skip-checks
-      type: string
-    - default: "false"
-      description: Execute the build with network isolation
-      name: hermetic
-      type: string
-    - default: ""
-      description: Build dependencies to be prefetched by Cachi2
-      name: prefetch-input
-      type: string
-    - default: ""
-      description: Image tag expiration time, time values could be something like
-        1h, 2d, 3w for hours, days, and weeks, respectively.
-      name: image-expires-after
-    - default: "false"
-      description: Build a source image.
-      name: build-source-image
-      type: string
-    - default: "true"
-      description: Add built image into an OCI image index
-      name: build-image-index
-      type: string
-    - default: []
-      description: Array of --build-arg values ("arg=value" strings) for buildah
-      name: build-args
-      type: array
-    - default: ""
-      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
-      name: build-args-file
-      type: string
-    - default:
-      - linux/x86_64
-      # Disable arm builds until they are in-cluster or much faster!
-      # - linux/arm64
-      description: List of platforms to build the container images on. The available
-        set of values is determined by the configuration of the multi-platform-controller.
-      name: build-platforms
-      type: array
-    - default: ""
-      description: Specify which stage to build in a multi-stage Dockerfile.
-      name: target-stage
-      type: string
-    workspaces:
-    - name: git-auth
-      optional: true
-    - name: netrc
-      optional: true
-    results:
-    - description: ""
-      name: IMAGE_URL
+    - name: IMAGE_URL
       value: $(tasks.build-image-index.results.IMAGE_URL)
-    - description: ""
-      name: IMAGE_DIGEST
-      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-    - description: ""
-      name: CHAINS-GIT_URL
-      value: $(tasks.clone-repository.results.url)
-    - description: ""
-      name: CHAINS-GIT_COMMIT
-      value: $(tasks.clone-repository.results.commit)
-    finally:
-    - name: show-sbom
+    taskRef:
       params:
-      - name: IMAGE_URL
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      taskRef:
-        params:
-        - name: name
-          value: show-sbom
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:945a7c9066d3e0a95d3fddb7e8a6992e4d632a2a75d8f3a9bd2ff2fef0ec9aa0
-        - name: kind
-          value: task
-        resolver: bundles
+      - name: name
+        value: show-sbom
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:52f8b96b96ce4203d4b74d850a85f963125bf8eef0683ea5acdd80818d335a28
+      - name: kind
+        value: task
+      resolver: bundles
+  - name: show-summary
+    params:
+    - name: pipelinerun-name
+      value: $(context.pipelineRun.name)
+    - name: git-url
+      value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
+    - name: image-url
+      value: $(params.output-image)
+    - name: build-task-status
+      value: $(tasks.build-image-index.status)
+    taskRef:
+      params:
+      - name: name
+        value: summary
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-summary:0.2@sha256:d97c04ab42f277b1103eb6f3a053b247849f4f5b3237ea302a8ecada3b24e15b
+      - name: kind
+        value: task
+      resolver: bundles
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  params:
+  - default: ""
+    description: Specify which stage to build in a multi-stage Dockerfile.
+    name: target-stage
+    type: string
+  - description: Source Repository URL
+    name: git-url
+    type: string
+  - default: ""
+    description: Revision of the Source Repository
+    name: revision
+    type: string
+  - description: Fully Qualified Output Image
+    name: output-image
+    type: string
+  - default: .
+    description: Path to the source code of an application's component from where
+      to build image.
+    name: path-context
+    type: string
+  - default: Dockerfile
+    description: Path to the Dockerfile inside the context specified by parameter
+      path-context
+    name: dockerfile
+    type: string
+  - default: "false"
+    description: Force rebuild image
+    name: rebuild
+    type: string
+  - default: "false"
+    description: Skip checks against built image
+    name: skip-checks
+    type: string
+  - default: "false"
+    description: Execute the build with network isolation
+    name: hermetic
+    type: string
+  - default: ""
+    description: Build dependencies to be prefetched by Cachi2
+    name: prefetch-input
+    type: string
+  - default: ""
+    description: Image tag expiration time, time values could be something like
+      1h, 2d, 3w for hours, days, and weeks, respectively.
+    name: image-expires-after
+  - default: "false"
+    description: Build a source image.
+    name: build-source-image
+    type: string
+  - default: "false"
+    description: Add built image into an OCI image index
+    name: build-image-index
+    type: string
+  - default: []
+    description: Array of --build-arg values ("arg=value" strings) for buildah
+    name: build-args
+    type: array
+  - default: ""
+    description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    name: build-args-file
+    type: string
+  results:
+  - description: ""
+    name: IMAGE_URL
+    value: $(tasks.build-image-index.results.IMAGE_URL)
+  - description: ""
+    name: IMAGE_DIGEST
+    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+  - description: ""
+    name: CHAINS-GIT_URL
+    value: $(tasks.clone-repository.results.url)
+  - description: ""
+    name: CHAINS-GIT_COMMIT
+    value: $(tasks.clone-repository.results.commit)
+  tasks:
+  - name: init
+    params:
+    - name: image-url
+      value: $(params.output-image)
+    - name: rebuild
+      value: $(params.rebuild)
+    - name: skip-checks
+      value: $(params.skip-checks)
+    taskRef:
+      params:
+      - name: name
+        value: init
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:f239f38bba3a8351c8cb0980fde8e2ee477ded7200178b0f45175e4006ff1dca
+      - name: kind
+        value: task
+      resolver: bundles
+  - name: clone-repository
+    params:
+    - name: url
+      value: $(params.git-url)
+    - name: revision
+      value: $(params.revision)
+    runAfter:
+    - init
+    taskRef:
+      params:
+      - name: name
+        value: git-clone
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-git-clone:0.1@sha256:2cccdf8729ad4d5adf65e8b66464f8efa1e1c87ba16d343b4a6c621a2a40f7e1
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: output
+      workspace: workspace
+    - name: basic-auth
+      workspace: git-auth
+  - name: prefetch-dependencies
+    params:
+    - name: input
+      value: $(params.prefetch-input)
+    runAfter:
+    - clone-repository
+    taskRef:
+      params:
+      - name: name
+        value: prefetch-dependencies
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.1@sha256:f53fe5482599b39ae2d1004cf09a2026fd9dd3822ab6ef46b51b4a398b0a3232
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.prefetch-input)
+      operator: notin
+      values:
+      - ""
+    workspaces:
+    - name: source
+      workspace: workspace
+    - name: git-basic-auth
+      workspace: git-auth
+    - name: netrc
+      workspace: netrc
+  - name: build-container
+    params:
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: HERMETIC
+      value: $(params.hermetic)
+    - name: TARGET_STAGE
+      value: $(params.target-stage)
+    - name: PREFETCH_INPUT
+      value: $(params.prefetch-input)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: BUILD_ARGS
+      value:
+      - $(params.build-args[*])
+    - name: BUILD_ARGS_FILE
+      value: $(params.build-args-file)
+    runAfter:
+    - prefetch-dependencies
+    taskRef:
+      params:
+      - name: name
+        value: buildah
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.2@sha256:11b7f08ddaa281fcf40494a2a2f79e0aebcaa3e7da93790fecad4d46983648d2
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: source
+      workspace: workspace
+  - name: build-image-index
+    params:
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: ALWAYS_BUILD_INDEX
+      value: $(params.build-image-index)
+    - name: IMAGES
+      value:
+      - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+    runAfter:
+    - build-container
+    taskRef:
+      params:
+      - name: name
+        value: build-image-index
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:5da8c2f09990b801f1fd02a0ab3c4136845661e53c98e8a7ebf720774e064fac
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+  - name: build-source-image
+    params:
+    - name: BINARY_IMAGE
+      value: $(params.output-image)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: source-build
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-source-build:0.1@sha256:53a41b0838b61cbacc7ecd4ffd87cf3f41b28a4aa9e095fe95779982c688dc85
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    - input: $(params.build-source-image)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: deprecated-base-image-check
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: deprecated-image-check
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.4@sha256:443ffa897ee35e416a0bfd39721c68cbf88cfa5c74c843c5183218d0cd586e82
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: clair-scan
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: clair-scan
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:90e371fe7ec2288259a906bc1fd49c53b8b97a0b0b02da0893fb65e3be2a5801
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: ecosystem-cert-preflight-checks
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: ecosystem-cert-preflight-checks
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:5131cce0f93d0b728c7bcc0d6cee4c61d4c9f67c6d619c627e41e3c9775b497d
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: sast-snyk-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: sast-snyk-check
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check:0.2@sha256:eb7c643130f226c345b3602dca280e6f8cd6f90f948503918d5a2677bf0610f7
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: clamav-scan
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: clamav-scan
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.1@sha256:21c7d037df3b430fc5c21b932e2062d0b82b046f39a2dc965aba7dff7a9cfc57
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: apply-tags
+    params:
+    - name: IMAGE
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: apply-tags
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:87fd7fc0e937aad1a8db9b6e377d7e444f53394dafde512d68adbea6966a4702
+      - name: kind
+        value: task
+      resolver: bundles
+  - name: push-dockerfile
+    params:
+    - name: IMAGE
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: push-dockerfile
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile:0.1@sha256:a216178a1cd4906b6d7a9133d88a803a1d8cae1f8c764f4dd89e9a551e310166
+      - name: kind
+        value: task
+      resolver: bundles
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: rpms-signature-scan
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      params:
+      - name: name
+        value: rpms-signature-scan
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:0c9667fba291af05997397a32e5e938ccaa46e93a2e14bad228e64a6427c5545
+      - name: kind
+        value: task
+      resolver: bundles
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  workspaces:
+  - name: workspace
+  - name: git-auth
+    optional: true
+  - name: netrc
+    optional: true
+
+# https://github.com/konflux-ci/build-definitions
+# https://konflux.pages.redhat.com/docs/users/getting-started/multi-platform-builds.html
+# TODO: Re-enable once arm builds are stable
+#apiVersion: tekton.dev/v1
+#kind: Pipeline
+#metadata:
+#  name: multi-arch-build-pipeline
+#spec:
+#    tasks:
+#    - name: init
+#      params:
+#      - name: image-url
+#        value: $(params.output-image)
+#      - name: rebuild
+#        value: $(params.rebuild)
+#      - name: skip-checks
+#        value: $(params.skip-checks)
+#      taskRef:
+#        params:
+#        - name: name
+#          value: init
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-init:0.2@sha256:0523b51c28375a3f222da91690e22eff11888ebc98a0c73c468af44762265c69
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#    - name: clone-repository
+#      params:
+#      - name: url
+#        value: $(params.git-url)
+#      - name: revision
+#        value: $(params.revision)
+#      - name: ociStorage
+#        value: $(params.output-image).git
+#      - name: ociArtifactExpiresAfter
+#        value: $(params.image-expires-after)
+#      runAfter:
+#      - init
+#      taskRef:
+#        params:
+#        - name: name
+#          value: git-clone-oci-ta
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:4bf48d038ff12d25bdeb5ab3e98dc2271818056f454c83d7393ebbd413028147
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(tasks.init.results.build)
+#        operator: in
+#        values:
+#        - "true"
+#      workspaces:
+#      - name: basic-auth
+#        workspace: git-auth
+#    - name: prefetch-dependencies
+#      params:
+#      - name: input
+#        value: $(params.prefetch-input)
+#      - name: SOURCE_ARTIFACT
+#        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+#      - name: ociStorage
+#        value: $(params.output-image).prefetch
+#      - name: ociArtifactExpiresAfter
+#        value: $(params.image-expires-after)
+#      runAfter:
+#      - clone-repository
+#      taskRef:
+#        params:
+#        - name: name
+#          value: prefetch-dependencies-oci-ta
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.1@sha256:30c903144e8c8d8c65fb6ec40dd3ff737091609f96fa9f326c047f71242dade4
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      workspaces:
+#      - name: git-basic-auth
+#        workspace: git-auth
+#      - name: netrc
+#        workspace: netrc
+#    - matrix:
+#        params:
+#        - name: PLATFORM
+#          value:
+#          - $(params.build-platforms)
+#      name: build-images
+#      params:
+#      - name: IMAGE
+#        value: $(params.output-image)
+#      - name: DOCKERFILE
+#        value: $(params.dockerfile)
+#      - name: CONTEXT
+#        value: $(params.path-context)
+#      - name: HERMETIC
+#        value: $(params.hermetic)
+#      - name: PREFETCH_INPUT
+#        value: $(params.prefetch-input)
+#      - name: IMAGE_EXPIRES_AFTER
+#        value: $(params.image-expires-after)
+#      - name: TARGET_STAGE
+#        value: $(params.target-stage)
+#      - name: COMMIT_SHA
+#        value: $(tasks.clone-repository.results.commit)
+#      - name: BUILD_ARGS
+#        value:
+#        - $(params.build-args[*])
+#      - name: BUILD_ARGS_FILE
+#        value: $(params.build-args-file)
+#      - name: SOURCE_ARTIFACT
+#        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+#      - name: CACHI2_ARTIFACT
+#        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+#      - name: IMAGE_APPEND_PLATFORM
+#        value: "true"
+#      runAfter:
+#      - prefetch-dependencies
+#      taskRef:
+#        params:
+#        - name: name
+#          value: buildah-remote-oci-ta
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:d582f95f21735f44947c62c2976972dc062cba20e6a3694990bafd5827665bb7
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(tasks.init.results.build)
+#        operator: in
+#        values:
+#        - "true"
+#    - name: build-image-index
+#      params:
+#      - name: IMAGE
+#        value: $(params.output-image)
+#      - name: COMMIT_SHA
+#        value: $(tasks.clone-repository.results.commit)
+#      - name: IMAGE_EXPIRES_AFTER
+#        value: $(params.image-expires-after)
+#      - name: ALWAYS_BUILD_INDEX
+#        value: $(params.build-image-index)
+#      - name: IMAGES
+#        value:
+#        - $(tasks.build-images.results.IMAGE_REF[*])
+#      runAfter:
+#      - build-images
+#      taskRef:
+#        params:
+#        - name: name
+#          value: build-image-index
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:ebc17bb22481160eec6eb7277df1e48b90f599bebe563cd4f046807f4e32ced3
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(tasks.init.results.build)
+#        operator: in
+#        values:
+#        - "true"
+#    - name: build-source-image
+#      params:
+#      - name: BINARY_IMAGE
+#        value: $(params.output-image)
+#      - name: SOURCE_ARTIFACT
+#        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+#      - name: CACHI2_ARTIFACT
+#        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+#      runAfter:
+#      - build-image-index
+#      taskRef:
+#        params:
+#        - name: name
+#          value: source-build-oci-ta
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.1@sha256:bd786bc1d33391bb169f98a1070d1a39e410b835f05fd0db0263754c65bd9bea
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(tasks.init.results.build)
+#        operator: in
+#        values:
+#        - "true"
+#      - input: $(params.build-source-image)
+#        operator: in
+#        values:
+#        - "true"
+#    - name: deprecated-base-image-check
+#      params:
+#      - name: IMAGE_URL
+#        value: $(tasks.build-image-index.results.IMAGE_URL)
+#      - name: IMAGE_DIGEST
+#        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+#      runAfter:
+#      - build-image-index
+#      taskRef:
+#        params:
+#        - name: name
+#          value: deprecated-image-check
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.4@sha256:5a1a165fa02270f0a947d8a2131ee9d8be0b8e9d34123828c2bef589e504ee84
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.skip-checks)
+#        operator: in
+#        values:
+#        - "false"
+#    - name: clair-scan
+#      params:
+#      - name: image-digest
+#        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+#      - name: image-url
+#        value: $(tasks.build-image-index.results.IMAGE_URL)
+#      runAfter:
+#      - build-image-index
+#      taskRef:
+#        params:
+#        - name: name
+#          value: clair-scan
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:0a5421111e7092740398691d5bd7c125cc0896f29531d19414bb5724ae41692a
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.skip-checks)
+#        operator: in
+#        values:
+#        - "false"
+#    - name: ecosystem-cert-preflight-checks
+#      params:
+#      - name: image-url
+#        value: $(tasks.build-image-index.results.IMAGE_URL)
+#      runAfter:
+#      - build-image-index
+#      taskRef:
+#        params:
+#        - name: name
+#          value: ecosystem-cert-preflight-checks
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:df8a25a3431a70544172ed4844f9d0c6229d39130633960729f825a031a7dea9
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.skip-checks)
+#        operator: in
+#        values:
+#        - "false"
+#    - name: sast-snyk-check
+#      params:
+#      - name: image-digest
+#        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+#      - name: image-url
+#        value: $(tasks.build-image-index.results.IMAGE_URL)
+#      - name: SOURCE_ARTIFACT
+#        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+#      - name: CACHI2_ARTIFACT
+#        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+#      runAfter:
+#      - build-image-index
+#      taskRef:
+#        params:
+#        - name: name
+#          value: sast-snyk-check-oci-ta
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.3@sha256:65a213322ea7c64159e37071d369d74b6378b23403150e29537865cada90f022
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.skip-checks)
+#        operator: in
+#        values:
+#        - "false"
+#    - name: clamav-scan
+#      params:
+#      - name: image-digest
+#        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+#      - name: image-url
+#        value: $(tasks.build-image-index.results.IMAGE_URL)
+#      runAfter:
+#      - build-image-index
+#      taskRef:
+#        params:
+#        - name: name
+#          value: clamav-scan
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.1@sha256:b4f450f1447b166da671f1d5819ab5a1485083e5c27ab91f7d8b7a2ff994c8c2
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.skip-checks)
+#        operator: in
+#        values:
+#        - "false"
+#    - name: apply-tags
+#      params:
+#      - name: IMAGE
+#        value: $(tasks.build-image-index.results.IMAGE_URL)
+#      runAfter:
+#      - build-image-index
+#      taskRef:
+#        params:
+#        - name: name
+#          value: apply-tags
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.1@sha256:87fd7fc0e937aad1a8db9b6e377d7e444f53394dafde512d68adbea6966a4702
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#    - name: push-dockerfile
+#      params:
+#      - name: IMAGE
+#        value: $(tasks.build-image-index.results.IMAGE_URL)
+#      - name: IMAGE_DIGEST
+#        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+#      - name: DOCKERFILE
+#        value: $(params.dockerfile)
+#      - name: CONTEXT
+#        value: $(params.path-context)
+#      - name: SOURCE_ARTIFACT
+#        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+#      runAfter:
+#      - build-image-index
+#      taskRef:
+#        params:
+#        - name: name
+#          value: push-dockerfile-oci-ta
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.1@sha256:80d48a1b9d2707490309941ec9f79338533938f959ca9a207b481b0e8a5e7a93
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#    - name: rpms-signature-scan
+#      params:
+#      - name: image-url
+#        value: $(tasks.build-image-index.results.IMAGE_URL)
+#      - name: image-digest
+#        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+#      runAfter:
+#      - build-image-index
+#      taskRef:
+#        params:
+#        - name: name
+#          value: rpms-signature-scan
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:28aaf87d61078a0aeeeabcae455eda7d05c4f9b81d8995bdcf3dde95c1a7a77b
+#        - name: kind
+#          value: task
+#        resolver: bundles
+#      when:
+#      - input: $(params.skip-checks)
+#        operator: in
+#        values:
+#        - "false"
+#    params:
+#    - description: Source Repository URL
+#      name: git-url
+#      type: string
+#    - default: ""
+#      description: Revision of the Source Repository
+#      name: revision
+#      type: string
+#    - description: Fully Qualified Output Image
+#      name: output-image
+#      type: string
+#    - default: .
+#      description: Path to the source code of an application's component from where
+#        to build image.
+#      name: path-context
+#      type: string
+#    - default: Dockerfile
+#      description: Path to the Dockerfile inside the context specified by parameter
+#        path-context
+#      name: dockerfile
+#      type: string
+#    - default: "false"
+#      description: Force rebuild image
+#      name: rebuild
+#      type: string
+#    - default: "false"
+#      description: Skip checks against built image
+#      name: skip-checks
+#      type: string
+#    - default: "false"
+#      description: Execute the build with network isolation
+#      name: hermetic
+#      type: string
+#    - default: ""
+#      description: Build dependencies to be prefetched by Cachi2
+#      name: prefetch-input
+#      type: string
+#    - default: ""
+#      description: Image tag expiration time, time values could be something like
+#        1h, 2d, 3w for hours, days, and weeks, respectively.
+#      name: image-expires-after
+#    - default: "false"
+#      description: Build a source image.
+#      name: build-source-image
+#      type: string
+#    - default: "true"
+#      description: Add built image into an OCI image index
+#      name: build-image-index
+#      type: string
+#    - default: []
+#      description: Array of --build-arg values ("arg=value" strings) for buildah
+#      name: build-args
+#      type: array
+#    - default: ""
+#      description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+#      name: build-args-file
+#      type: string
+#    - default:
+#      - linux/x86_64
+#      - linux/arm64
+#      description: List of platforms to build the container images on. The available
+#        set of values is determined by the configuration of the multi-platform-controller.
+#      name: build-platforms
+#      type: array
+#    - default: ""
+#      description: Specify which stage to build in a multi-stage Dockerfile.
+#      name: target-stage
+#      type: string
+#    workspaces:
+#    - name: git-auth
+#      optional: true
+#    - name: netrc
+#      optional: true
+#    results:
+#    - description: ""
+#      name: IMAGE_URL
+#      value: $(tasks.build-image-index.results.IMAGE_URL)
+#    - description: ""
+#      name: IMAGE_DIGEST
+#      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+#    - description: ""
+#      name: CHAINS-GIT_URL
+#      value: $(tasks.clone-repository.results.url)
+#    - description: ""
+#      name: CHAINS-GIT_COMMIT
+#      value: $(tasks.clone-repository.results.commit)
+#    finally:
+#    - name: show-sbom
+#      params:
+#      - name: IMAGE_URL
+#        value: $(tasks.build-image-index.results.IMAGE_URL)
+#      taskRef:
+#        params:
+#        - name: name
+#          value: show-sbom
+#        - name: bundle
+#          value: quay.io/konflux-ci/tekton-catalog/task-show-sbom:0.1@sha256:945a7c9066d3e0a95d3fddb7e8a6992e4d632a2a75d8f3a9bd2ff2fef0ec9aa0
+#        - name: kind
+#          value: task
+#        resolver: bundles


### PR DESCRIPTION
Multi-arch manifests might cause issues on mac if we do not build for arm platform too.

Currently, arm builds are not reliable/slow in Konflux, so we would like to disable them.

In this PR we move to single arch manifest pipelines (temporarily).