### PR TITLE
feat(renovate): group all non major dep updates in one pr

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -4,7 +4,8 @@
     "github>konflux-ci/mintmaker//config/renovate/renovate.json",
     "config:best-practices",
     ":automergeDigest",
-    "group:allDigest"
+    "group:allDigest",
+    "group:allNonMajor"
   ],
   "updateNotScheduled": true,
   "dockerfile": {


### PR DESCRIPTION
To reduce open prs related to dependency update, grouping all non major ones together.

Verified in https://github.com/app-sre/er-aws-elasticache/pull/102, example new pr https://github.com/app-sre/er-aws-elasticache/pull/104.