### PR TITLE
feat(renovate): automerge pin and pinDigest prs

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -57,6 +57,12 @@
       "automerge": true
     }
   ],
+  "pin": {
+    "automerge": true
+  },
+  "pinDigest": {
+    "automerge": true
+  },
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true


### PR DESCRIPTION
This pull request includes updates to the `renovate/default.json` configuration file to enhance the automation of dependency management by enabling automerge for pinned dependencies and digest updates.

Configuration enhancements:

* [`renovate/default.json`](diffhunk://#diff-ce2fec27cf32b37dd58b6e67b691ed5721238fbff4a0ea70077e0934e8ac8e3aR60-R65): Added automerge settings for pinned dependencies (`pin`) and digest updates (`pinDigest`).

Verified in https://github.com/app-sre/er-aws-rds/pull/76