### PR TITLE
disable terraform updates

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -55,6 +55,10 @@
       "datasources": ["pypi"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
+    },
+    {
+      "matchPackageNames": ["hashicorp/terraform", "terraform"],
+      "enabled": false
     }
   ],
   "pin": {


### PR DESCRIPTION
We need to disable automatic `terraform` updates until all license-related and IBM bought Hashicorp changes are sorted out. E.g. https://github.com/app-sre/er-aws-elasticache/pull/125