### PR TITLE
feat(renovate): group non major dependencies by manager

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -4,8 +4,7 @@
     "github>konflux-ci/mintmaker//config/renovate/renovate.json",
     "config:best-practices",
     ":automergeDigest",
-    "group:allDigest",
-    "group:allNonMajor"
+    "group:allDigest"
   ],
   "updateNotScheduled": true,
   "dockerfile": {
@@ -26,6 +25,17 @@
   "dependencyDashboard": true,
   "semanticCommits": "enabled",
   "packageRules": [
+    {
+      "groupName": "all non-major {{manager}} dependencies",
+      "groupSlug": "all-minor-patch-{{manager}}",
+      "matchPackageNames": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ]
+    },
     {
       "matchPackageNames": ["pytest**"],
       "groupName": "pytest"


### PR DESCRIPTION
Verified in https://github.com/app-sre/er-aws-rds/pull/126, so dependencies by different managers (python, terraform...) can be in different PRs, easier to manage and merge.

Example PRs:

* https://github.com/app-sre/er-aws-rds/pull/128
* https://github.com/app-sre/er-aws-rds/pull/133