### PR TITLE
feat(renovate): disable python major/minor upgrade

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -72,6 +72,13 @@
       "automerge": true
     },
     {
+      "description": "Disable automatic updates for Python major/minor versions",
+      "matchDatasources": ["python-version"],
+      "matchPackageNames": ["python"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    },
+    {
       "matchPackageNames": ["hashicorp/terraform", "terraform"],
       "enabled": false
     }


### PR DESCRIPTION
to avoid prs like https://github.com/app-sre/er-aws-rds/pull/163 to include `python`