### PR TITLE
APPSRE-11020 allow to fetch tags

### DIFF
--- a/pipelines/multi-arch-build-pipeline.bak.yaml
+++ b/pipelines/multi-arch-build-pipeline.bak.yaml
@@ -25,6 +25,9 @@ spec:
       resolver: bundles
   - name: clone-repository
     params:
+    # https://github.com/konflux-ci/build-definitions/tree/main/task/git-clone-oci-ta/0.1
+    - name: fetchTags
+      value: $(params.fetchTags)
     - name: url
       value: $(params.git-url)
     - name: revision
@@ -414,6 +417,11 @@ spec:
       values:
       - "false"
   params:
+  - default: "false"
+    # https://github.com/konflux-ci/build-definitions/tree/main/task/git-clone-oci-ta/0.1
+    description: Fetch all tags for the repo.
+    name: fetchTags
+    type: string
   - description: Source Repository URL
     name: git-url
     type: string

--- a/pipelines/multi-arch-build-pipeline.yaml
+++ b/pipelines/multi-arch-build-pipeline.yaml
@@ -102,6 +102,11 @@ spec:
     description: Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET
     name: additional_secret
     type: string
+  - default: "false"
+    # https://github.com/konflux-ci/build-definitions/tree/main/task/git-clone/0.1
+    description: Fetch all tags for the repo.
+    name: fetchTags
+    type: string
   results:
   - description: ""
     name: IMAGE_URL
@@ -139,6 +144,9 @@ spec:
       value: $(params.git-url)
     - name: revision
       value: $(params.revision)
+    # https://github.com/konflux-ci/build-definitions/tree/main/task/git-clone/0.1
+    - name: fetchTags
+      value: $(params.fetchTags)
     runAfter:
     - init
     taskRef:


### PR DESCRIPTION
By default we always have a shallow git clone of depth 1.

For qr builds we need tags history for infer proper version.