### PR TITLE
APPSRE-11505 remove redundant clone condition

### DIFF
--- a/pipelines/multi-arch-build-pipeline.yaml
+++ b/pipelines/multi-arch-build-pipeline.yaml
@@ -589,6 +589,10 @@ spec:
       operator: in
       values:
       - "true"
+    - input: "$(params.ephemeral-namespace-run-script)$(params.goss-container-structure-test-file)"
+      operator: notin
+      values:
+      - ""
     workspaces:
     - name: basic-auth
       workspace: git-auth


### PR DESCRIPTION
We dont need oci-ta clone if we are not using ephemeral deployment for now.