### PR TITLE
Revert "add default minimumReleaseAge"

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -9,7 +9,6 @@
   "updateNotScheduled": true,
   "dependencyDashboard": true,
   "semanticCommits": "enabled",
-  "minimumReleaseAge": "1 day",
   "packageRules": [
     {
       "description": "Red Hat Versioning docker images",


### PR DESCRIPTION
Unset `minimumReleaseAge ` because of [KONFLUX-7964](https://issues.redhat.com/browse/KONFLUX-7964). See https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1759749284925799?thread_ts=1759466254.474289&cid=C04PZ7H0VA8 for more details.