### PR TITLE
fix: deploy ephemeral namespace after build-container

### DIFF
--- a/pipelines/multi-arch-build-pipeline.yaml
+++ b/pipelines/multi-arch-build-pipeline.yaml
@@ -614,6 +614,7 @@ spec:
   - name: deploy-ephemeral-namespace
     runAfter:
     - clone-repository-oci-ta
+    - build-container
     taskRef:
       resolver: git
       params:


### PR DESCRIPTION
## Summary

- `deploy-ephemeral-namespace` was starting in parallel with `build-container` (both running after `init` via separate chains)
- Added `build-container` to `deploy-ephemeral-namespace`'s `runAfter` so namespace provisioning only starts once the image is built

## Test plan

- [ ] Verify pipeline run shows `deploy-ephemeral-namespace` starting after `build-container` completes
- [ ] Verify ephemeral namespace tasks (`container-structure-test`, `run-custom-script-in-ephemeral-namespace`) still run correctly