### PR TITLE
chore(renovate): track uv version in .tool-versions

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -18,6 +18,14 @@
       "matchStrings": ["\\[tool\\.uv\\]\\srequired-version = \">=(?<currentValue>[\\d.]+)\""],
       "depNameTemplate": "ghcr.io/astral-sh/uv",
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "Update uv version in .tool-versions",
+      "fileMatch": ["(^|/)\\.tool-versions$"],
+      "matchStrings": ["(?:^|\\r\\n|\\r|\\n)uv (?<currentValue>[\\d.]+)"],
+      "depNameTemplate": "ghcr.io/astral-sh/uv",
+      "datasourceTemplate": "docker"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
## Summary
- Add a customManager for `.tool-versions` reusing the `ghcr.io/astral-sh/uv` / `docker` dependency identity already used by the `pyproject.toml` uv manager, so Renovate bundles both version bumps into a single PR in any repo extending this preset.
- Anchor the regex to line boundaries (`(?:^|\r\n|\r|\n)uv `) since Renovate's regex manager matches per-file, not per-line, and a bare `uv ` substring match could false-positive on other tool names ending in `...uv`.

## Test plan
- [ ] Confirm Renovate picks up both `pyproject.toml` and `.tool-versions` uv references in one grouped PR in a repo extending this config (e.g. qontract-reconcile)
- [ ] Close/strip the duplicate local `customManagers` override in app-sre/qontract-reconcile#5744 once this merges, since `customManagers` arrays are mergeable/concatenated on `extends`